### PR TITLE
Use window.derwin instead of window.newwin

### DIFF
--- a/cursedui/cursedui.py
+++ b/cursedui/cursedui.py
@@ -94,7 +94,7 @@ class CursedUI:
                 if tileHeight <= 1:
                     continue
 
-                tileWindow = curses.newwin(tileHeight, tileWidth, curHeight, 0)
+                tileWindow = stdscr.derwin(tileHeight, tileWidth, curHeight, 0)
                 tile.refresh(tileWindow)
                 curHeight += tileHeight
 


### PR DESCRIPTION
Fixes the tile disappearing if it is not required to be refreshened, while others do.